### PR TITLE
Stop reading DBFs at the end of the file.

### DIFF
--- a/dbf/DbfTable.cpp
+++ b/dbf/DbfTable.cpp
@@ -145,7 +145,7 @@ void DbfTable::read_columns(std::istream &stream) {
     int index = 0;
     columns_.clear();
 
-    while (stream.peek() != 0x0D) {
+    while (stream.peek() != 0x0D && !stream.eof()) {
         DbfColumnPtr column = DbfColumnPtr(new DbfColumn(stream, index++));
         columns_.push_back(column);
     }


### PR DESCRIPTION
This will cause DBFs only contain 0x00 bytes to be reported back as unreadable. At present they'll cause dbf2csv to allocate all system member available on the system before crashing. This addresses #3 